### PR TITLE
Ignore warnings on stderr if stdout is not empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ nodeSlicer.render = function (options, callback) {
 		shellCommand,
 		function (error, stdout, stderr) {
 
-			if (stderr){
+			if (stderr && !stdout){
 				return callback({ message: stderr })
 			}
 


### PR DESCRIPTION
There are cases where `slic3r` reports warnings on `stderr` , e.g. `Warning: the supplied parts might not fit in the configured bed shape. You might want to review the result before printing.`
In that case there is still valid sliced output on `stdout`, which currently is not made available through the lib.

By extending the check as proposed, these warnings will be ignored and not result in an error callback without any data about the slicer result